### PR TITLE
spm_mkdtemp requires a base directory:

### DIFF
--- a/include/fs.h
+++ b/include/fs.h
@@ -39,7 +39,7 @@ char *basename(char *path);
 int rsync(const char *_args, const char *_source, const char *_destination);
 char *human_readable_size(uint64_t n);
 char *expandpath(const char *_path);
-char *spm_mkdtemp(const char *name, const char *extended_path);
+char *spm_mkdtemp(const char *base, const char *name, const char *extended_path);
 int touch(const char *path);
 
 

--- a/lib/fs.c
+++ b/lib/fs.c
@@ -576,19 +576,27 @@ char *human_readable_size(uint64_t n) {
 
 /**
  * Create a named temporary directory
- * @param name
+ * @param base path where temporary directory will be created
+ * @param name name of temporary directory
+ * @param extended_path a subdirectory to create beneath `base/name`, may be NULL
  * @return success=path, failure=NULL
  */
-char *spm_mkdtemp(const char *name, const char *extended_path) {
+char *spm_mkdtemp(const char *base, const char *name, const char *extended_path) {
     const char *template_unique = "XXXXXX";
     char *tmpdir = NULL;
     char template[PATH_MAX];
 
-    sprintf(template, "%s%s%s_%s", TMP_DIR, DIRSEPS, name, template_unique);
+    if (base == NULL || name == NULL) {  // extended_path is optional
+        return NULL;
+    }
+
+    sprintf(template, "%s%s%s_%s", base, DIRSEPS, name, template_unique);
     tmpdir = mkdtemp(template);
+
     if (tmpdir == NULL) {
         return NULL;
     }
+
     if (extended_path != NULL) {
         char extended[PATH_MAX] = {0,};
         strncpy(extended, tmpdir, PATH_MAX - 1);

--- a/lib/install.c
+++ b/lib/install.c
@@ -180,7 +180,7 @@ int spm_do_install(SPM_Hierarchy *fs, ManifestList *mf, StrList *packages) {
     size_t num_requirements = 0;
     ManifestPackage **requirements = NULL;
     char source[PATH_MAX];
-    char *tmpdir = spm_mkdtemp("spm_destroot", NULL);
+    char *tmpdir = spm_mkdtemp(TMP_DIR, "spm_destroot", NULL);
 
     if (tmpdir == NULL) {
         perror("Could not create temporary destination root");

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -75,7 +75,7 @@ Manifest *manifest_from(const char *package_dir) {
     strncpy(info->origin, package_dir, SPM_PACKAGE_MEMBER_ORIGIN_SIZE);
 
 
-    char *tmpdir = spm_mkdtemp("spm_manifest_from", NULL);
+    char *tmpdir = spm_mkdtemp(TMP_DIR, "spm_manifest_from", NULL);
     if (!tmpdir) {
         perror("failed to create temporary directory");
         fprintf(SYSERROR);
@@ -390,7 +390,7 @@ Manifest *manifest_read(char *file_or_url) {
         strcpy(path, SPM_GLOBAL.package_dir);
     }
     else {
-        tmpdir = spm_mkdtemp("spm_manifest_read_XXXXXX", SPM_GLOBAL.repo_target);
+        tmpdir = spm_mkdtemp(TMP_DIR, "spm_manifest_read_XXXXXX", SPM_GLOBAL.repo_target);
         if (exists(tmpdir) != 0) {
             fprintf(stderr, "Failed to create temporary storage directory\n");
             fprintf(SYSERROR);

--- a/tests/test_spm_mkdtemp.c
+++ b/tests/test_spm_mkdtemp.c
@@ -8,15 +8,9 @@ struct TestCase testCase[] = {
 size_t numCases = sizeof(testCase) / sizeof(struct TestCase);
 
 int main(int argc, char *argv[]) {
-    // SPM initializes a series of global variables when the main program kicks off.
-    // We are not fully initializing SPM...
-
-    TMP_DIR = calloc(PATH_MAX, sizeof(char));
-    TMP_DIR[0] = '.';
-
     for (size_t i = 0; i < numCases; i++) {
-        char *result = spm_mkdtemp(testCase[i].arg[0].sptr, testCase[i].arg[2].sptr);
-        myassert(result != NULL, "unexpected NULL\n");
+        char *result = spm_mkdtemp(".", testCase[i].arg[0].sptr, testCase[i].arg[2].sptr);
+        myassert(result != NULL, "unexpected NULL on case %zu\n", i);
         int present = access(result, F_OK);
         myassert(present == 0, "%s: %s\n", result, strerror(errno));
         rmdirs(result);


### PR DESCRIPTION
* test_spm_mkdtemp revealed a difference in how variables are stored (Linux vs. MacOS)