### PR TITLE
Move SPM_GLOBAL.repo_target string usage out of mirror_clone

### DIFF
--- a/include/mirrors.h
+++ b/include/mirrors.h
@@ -9,6 +9,6 @@
 
 char **mirror_list(const char *filename);
 void mirror_list_free(char **m);
-void mirror_clone(Manifest *info, char *dest);
+int mirror_clone(Manifest *info, char *_dest);
 
 #endif //SPM_MIRRORS_H

--- a/lib/archive.c
+++ b/lib/archive.c
@@ -102,6 +102,10 @@ int tar_extract_archive(const char *_archive, const char *_destination) {
     }
 
     status = proc->returncode;
+    if (status != 0 && SPM_GLOBAL.verbose) {
+        fprintf(stderr, "%s", proc->output);
+    }
+
     shell_free(proc);
     free(archive);
     free(destination);

--- a/lib/install.c
+++ b/lib/install.c
@@ -230,6 +230,7 @@ void spm_show_packages(ManifestList *info) {
  * @return success=0, exists=1, error=-1 (general), -2 (unable to create `destroot`)
  */
 int spm_install(SPM_Hierarchy *fs, const char *tmpdir, const char *_package) {
+    int status_tar;
     char *package = strdup(_package);
 
     if (!package) {
@@ -241,8 +242,9 @@ int spm_install(SPM_Hierarchy *fs, const char *tmpdir, const char *_package) {
         printf("Extracting archive: %s\n", package);
     }
 
-    if (tar_extract_archive(package, tmpdir) != 0) {
-        fprintf(stderr, "%s: %s\n", package, strerror(errno));
+    status_tar = 0;
+    if ((status_tar = tar_extract_archive(package, tmpdir)) != 0) {
+        fprintf(stderr, "Extraction program returned non-zero: %d: %s\n", status_tar, package);
         free(package);
         return -1;
     }

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -388,25 +388,17 @@ Manifest *manifest_read(char *file_or_url) {
         strcpy(path, SPM_GLOBAL.package_dir);
     }
     else {
-        tmpdir = spm_mkdtemp(TMP_DIR, "spm_manifest_read_XXXXXX", SPM_GLOBAL.repo_target);
+        tmpdir = spm_mkdtemp(TMP_DIR, "spm_manifest_read_XXXXXX", NULL);
         if (exists(tmpdir) != 0) {
             fprintf(stderr, "Failed to create temporary storage directory\n");
             fprintf(SYSERROR);
             return NULL;
         }
 
-        snprintf(pathptr, PATH_MAX - 1, "%s%s%s%s%s", tmpdir, DIRSEPS, SPM_GLOBAL.repo_target, DIRSEPS, filename);
+        pathptr = join((char *[]) {tmpdir, filename, NULL}, DIRSEPS);
     }
 
-    const char *target_is;
-    if (strstr(file_or_url, SPM_GLOBAL.repo_target) != NULL) {
-        target_is = "";
-    }
-    else {
-        target_is = SPM_GLOBAL.repo_target;
-    }
-
-    char *remote_manifest = join_ex(DIRSEPS, file_or_url, target_is, filename, NULL);
+    char *remote_manifest = join_ex(DIRSEPS, file_or_url, filename, NULL);
 
     if (exists(pathptr) != 0) {
         // TODO: Move this out

--- a/lib/mirrors.c
+++ b/lib/mirrors.c
@@ -48,27 +48,28 @@ void mirror_list_free(char **m) {
     free(m);
 }
 
-void mirror_clone(Manifest *info, char *_dest) {
-    char *dest = NULL;
-    if (endswith(_dest, SPM_GLOBAL.repo_target) != 0) {
-        dest = strdup(_dest);
-    }
-    else {
-        dest = join((char *[]) {_dest, SPM_GLOBAL.repo_target, NULL}, DIRSEPS);
+int mirror_clone(Manifest *info, char *_dest) {
+    char *dest;
+    long response;
+
+    response = 0;
+    dest = strdup(_dest);
+    if (dest == NULL) {
+        perror("allocate dest string");
+        return 1;
     }
 
     if (exists(dest) != 0 && mkdirs(dest, 0755) != 0) {
         perror("Unable to create mirror directory");
         fprintf(SYSERROR);
-        exit(1);
+        return 1;
     }
 
     printf("Remote: %s\n", info->origin);
     printf("Local: %s\n", dest);
 
     for (size_t i = 0; i < info->records; i++) {
-        long response = 0;
-        char *archive = join((char *[]) {info->packages[i]->origin, SPM_GLOBAL.repo_target, info->packages[i]->archive, NULL}, DIRSEPS);
+        char *archive = join((char *[]) {dirname(info->origin), info->packages[i]->archive, NULL}, DIRSEPS);
         char *path = join((char *[]) {dest, info->packages[i]->archive, NULL}, DIRSEPS);
         if (exists(path) == 0) {
             char *checksum = sha256sum(path);
@@ -90,11 +91,11 @@ void mirror_clone(Manifest *info, char *_dest) {
 
     // Now fetch a copy of the physical manifest
     char *datafile = join((char *[]) {dest, basename(info->origin), NULL}, DIRSEPS);
-    long response = 0;
     if ((response = fetch(info->origin, datafile) >= 400)) {
         fprintf(stderr, "WARNING: HTTP(%ld, %s): %s\n", response, http_response_str(response), info->origin);
     }
+
     free(dest);
     free(datafile);
-    printf("done!\n");
+    return 0;
 }

--- a/src/spm.c
+++ b/src/spm.c
@@ -94,12 +94,14 @@ int main(int argc, char *argv[], char *arge[]) {
                 override_manifests = 1;
             }
             else if (strcmp(arg, "-m") == 0 || strcmp(arg, "--manifest") == 0) {
+                char *target;
                 if (arg_next == NULL) {
                     fprintf(stderr, "-m|--manifest requires a directory path\n");
                     usage();
                     exit(1);
                 }
-                manifestlist_append(mf, arg_next);
+                target = join((char *[]) {arg_next, SPM_GLOBAL.repo_target, NULL}, DIRSEPS);
+                manifestlist_append(mf, target);
                 i++;
             }
             else if (strcmp(arg, "--reindex") == 0) {
@@ -215,8 +217,12 @@ int main(int argc, char *argv[], char *arge[]) {
 
     // Apply some default manifest locations; unless the user passes -M|--override-manifests
     if (override_manifests == 0) {
+        char *target;
         // Remote package manifests have priority over the local package store
-        manifestlist_append(mf, "https://astroconda.org/spm");
+        target = join((char *[]) {"https://astroconda.org/spm", SPM_GLOBAL.repo_target, NULL}, DIRSEPS);
+        manifestlist_append(mf, target);
+        free(target);
+
         // Add the local package store to the bottom
         manifestlist_append(mf, SPM_GLOBAL.package_dir);
     }


### PR DESCRIPTION
* Assign targets from inside spm.c instead of external manifest/mirror functions